### PR TITLE
BROOKLYN-4090 - Create a periodic sensor functions to use admin_Creat…

### DIFF
--- a/components/sensors/imu/Component.cdef
+++ b/components/sensors/imu/Component.cdef
@@ -19,7 +19,11 @@ requires:
     api:
     {
         modemServices/le_adc.api
-        dhubIO = io.api
+#if ${MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE} = y
+        dhub = admin.api
+#else
+        dhub = io.api
+#endif
     }
 
     component:

--- a/components/sensors/imu/imu.c
+++ b/components/sensors/imu/imu.c
@@ -15,6 +15,11 @@
 #include "fileUtils.h"
 #include "periodicSensor.h"
 
+#ifdef MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE
+#define IMU_PREFIX_NAME   "/app/redSensor/"
+#else
+#define IMU_PREFIX_NAME   ""
+#endif
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -271,10 +276,10 @@ static void SampleTemp
 COMPONENT_INIT
 {
     // Use the Periodic Sensor component from the Data Hub to implement the sensor interfaces.
-    psensor_Create("gyro", DHUBIO_DATA_TYPE_JSON, "", SampleGyro, NULL);
-    psensor_Create("accel", DHUBIO_DATA_TYPE_JSON, "", SampleAccel, NULL);
-    psensor_Create("imu/temp", DHUBIO_DATA_TYPE_NUMERIC, "degC", SampleTemp, NULL);
+    psensor_Create(IMU_PREFIX_NAME "gyro", IO_DATA_TYPE_JSON, "", SampleGyro, NULL);
+    psensor_Create(IMU_PREFIX_NAME "accel", IO_DATA_TYPE_JSON, "", SampleAccel, NULL);
+    psensor_Create(IMU_PREFIX_NAME "imu/temp", IO_DATA_TYPE_NUMERIC, "degC", SampleTemp, NULL);
 
-    dhubIO_SetJsonExample("gyro/value", "{\"x\":0.1,\"y\":0.2,\"z\":0.3}");
-    dhubIO_SetJsonExample("accel/value", "{\"x\":0.1,\"y\":0.2,\"z\":0.3}");
+    dhub_SetJsonExample(IMU_PREFIX_NAME "gyro/value", "{\"x\":0.1,\"y\":0.2,\"z\":0.3}");
+    dhub_SetJsonExample(IMU_PREFIX_NAME "accel/value", "{\"x\":0.1,\"y\":0.2,\"z\":0.3}");
 }

--- a/components/sensors/light/Component.cdef
+++ b/components/sensors/light/Component.cdef
@@ -17,7 +17,11 @@ requires:
     api:
     {
         modemServices/le_adc.api
-        dhubIO = io.api
+#if ${MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE} = y
+        dhub = admin.api
+#else
+        dhub = io.api
+#endif
     }
 
     component:

--- a/components/sensors/light/lightSensor.c
+++ b/components/sensors/light/lightSensor.c
@@ -13,6 +13,12 @@
 #include "periodicSensor.h"
 #include "lightSensor.h"
 
+#ifdef MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE
+#define LIGHT_PREFIX_NAME   "/app/redSensor/"
+#else
+#define LIGHT_PREFIX_NAME   ""
+#endif
+
 const char lightSensorAdc[] = "EXT_ADC3";
 
 
@@ -39,7 +45,7 @@ static void Sample
 
 COMPONENT_INIT
 {
-    psensor_Create("light", DHUBIO_DATA_TYPE_NUMERIC, "", Sample, NULL);
+    psensor_Create(LIGHT_PREFIX_NAME "light", IO_DATA_TYPE_NUMERIC, "", Sample, NULL);
 }
 
 

--- a/components/sensors/pressure/Component.cdef
+++ b/components/sensors/pressure/Component.cdef
@@ -17,7 +17,11 @@ requires:
 {
     api:
     {
-        dhubIO = io.api
+#if ${MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE} = y
+        dhub = admin.api
+#else
+        dhub = io.api
+#endif
     }
 
     component:

--- a/components/sensors/pressure/pressureSensor.c
+++ b/components/sensors/pressure/pressureSensor.c
@@ -15,6 +15,12 @@
 #include "periodicSensor.h"
 #include "fileUtils.h"
 
+#ifdef MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE
+#define PRESSURE_PREFIX_NAME   "/app/redSensor/"
+#else
+#define PRESSURE_PREFIX_NAME   ""
+#endif
+
 static const char PressureFile[] = "/driver/in_pressure_input";
 static const char TemperatureFile[] = "/driver/in_temp_input";
 
@@ -110,6 +116,15 @@ COMPONENT_INIT
 {
     // Use the periodic sensor component from the Data Hub to implement the timers and the
     // interface to the Data Hub.
-    psensor_Create("pressure", DHUBIO_DATA_TYPE_NUMERIC, "kPa", SamplePressure, NULL);
-    psensor_Create("pressure/temp", DHUBIO_DATA_TYPE_NUMERIC, "degC", SampleTemperature, NULL);
+    psensor_Create(PRESSURE_PREFIX_NAME "pressure",
+                   IO_DATA_TYPE_NUMERIC,
+                   "kPa",
+                   SamplePressure,
+                   NULL);
+
+    psensor_Create(PRESSURE_PREFIX_NAME "pressure/temp",
+                   IO_DATA_TYPE_NUMERIC,
+                   "degC",
+                   SampleTemperature,
+                   NULL);
 }

--- a/redSensor.adef
+++ b/redSensor.adef
@@ -33,8 +33,15 @@ bindings:
     redSensor.light.le_adc -> modemService.le_adc
     redSensor.imu.le_adc -> modemService.le_adc
 
+#if ${MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE} = y
+    redSensor.periodicSensor.dhubIO -> dataHub.admin
+    redSensor.imu.dhub -> dataHub.admin
+    redSensor.light.dhub -> dataHub.admin
+    redSensor.pressure.dhub -> dataHub.admin
+#else
     redSensor.periodicSensor.dhubIO -> dataHub.io
-    redSensor.imu.dhubIO -> dataHub.io
-    redSensor.light.dhubIO -> dataHub.io
-    redSensor.pressure.dhubIO -> dataHub.io
+    redSensor.imu.dhub -> dataHub.io
+    redSensor.light.dhub -> dataHub.io
+    redSensor.pressure.dhub -> dataHub.io
+#endif
 }


### PR DESCRIPTION
…e/Delete API

These changes:

1) Extend the RedSensorToCloud components, IMU, Light, and Pressure, to use
absolute resource paths, which are now supported through
the Periodic Sensor component.

2) Utilize a new build flag, MK_CONFIG_PERIODIC_SENSOR_ABSOLUTE,
to determine whether resource paths are to be built/defined as absolute (new) or
relative (legacy).